### PR TITLE
Shorten options

### DIFF
--- a/fixtures/vcr_cassettes/shorten_long_url_with_preferred_domain.yml
+++ b/fixtures/vcr_cassettes/shorten_long_url_with_preferred_domain.yml
@@ -1,0 +1,38 @@
+---
+- !ruby/struct:VCR::HTTPInteraction
+  request: !ruby/struct:VCR::Request
+    method: :post
+    uri: http://api.bit.ly:80/v3/shorten
+    body: longURL=http%3A%2F%2Fgoogle.com&login=my-login&apiKey=my-secret-key&domain=j.mp
+    headers:
+      accept:
+      - ! '*/*; q=0.5, application/xml'
+      accept-encoding:
+      - gzip, deflate
+      content-length:
+      - '99'
+      content-type:
+      - application/x-www-form-urlencoded
+  response: !ruby/struct:VCR::Response
+    status: !ruby/struct:VCR::ResponseStatus
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Wed, 03 Apr 2013 19:39:42 GMT
+      content-type:
+      - application/json; charset=utf-8
+      connection:
+      - keep-alive
+      mime-version:
+      - '1.0'
+      content-length:
+      - '180'
+    body: ! '{ "status_code": 200, "status_txt": "OK", "data": { "long_url": "http:\/\/google.com\/",
+      "url": "http:\/\/j.mp\/XqfZJt", "hash": "XqfZJt", "global_hash": "LmvF", "new_hash":
+      3 } }
+
+'
+    http_version: '1.1'

--- a/lib/ruby-bitly.rb
+++ b/lib/ruby-bitly.rb
@@ -25,14 +25,21 @@ class Bitly < OpenStruct
     # :long_url
     # :login
     # :api_key
+    # :domain
     def shorten(new_long_url, login = self.login, key = self.key)
       if new_long_url.is_a?(Hash)
         options = new_long_url
         new_long_url = options[:long_url]
         login = options[:login] || self.login
         key = options[:api_key] || self.key
+      else
+        options = {}
       end
-      response = JSON.parse RestClient.post(REST_API_URL + ACTION_PATH[:shorten], { :longURL => new_long_url, :login => login, :apiKey => key })
+      params = { :longURL => new_long_url, :login => login, :apiKey => key }
+      if options[:domain]
+        params[:domain] = options[:domain]
+      end
+      response = JSON.parse RestClient.post(REST_API_URL + ACTION_PATH[:shorten], params)
       response.delete("data") if response["data"].empty?
 
       bitly = new response["data"]

--- a/spec/ruby-bitly_spec.rb
+++ b/spec/ruby-bitly_spec.rb
@@ -34,6 +34,20 @@ describe "RubyBitly" do
     response.url.should match /^http:\/\/bit\.ly\/[A-Za-z0-9]*/
   end
 
+  it 'Shorten url with a preferred domain' do
+    response = VCR.use_cassette('shorten_long_url_with_preferred_domain') do
+      Bitly.shorten(:long_url => "http://google.com", :domain => 'j.mp',
+        :login => @login, :api_key => @key)
+    end
+
+    response.status_code.should == 200
+    response.status_txt.should == "OK"
+    response.new_hash.should == 3
+    response.global_hash.should_not be_empty
+    response.hash_path.length.should_not == 0
+    response.url.should match /^http:\/\/j\.mp\/[A-Za-z0-9]*/
+  end
+
   it "Shorten bitly url" do
     response = VCR.use_cassette('shorten_bitly_url') do
       Bitly.shorten("http://bit.ly/bcvNe5", @login, @key)


### PR DESCRIPTION
Adds ability to specify preferred domain when shortening urls.

In order to do this, API of shorten method is changed to take a hash of options as an alternative to existing usage. Old arguments then become hash items. I renamed keys to be consistent with the api parameters.
